### PR TITLE
Feat#41 JWT RefreshToken 추가 및 코드 정리

### DIFF
--- a/config/db.config.js
+++ b/config/db.config.js
@@ -7,7 +7,7 @@ export const pool = mysql.createPool({
   user: process.env.DB_USER || 'root', // user 이름
   port: process.env.DB_PORT || '3306', // 포트 번호
   database: process.env.DB_TABLE || 'myplace_dev', // 데이터베이스 이름
-  password: process.env.DB_PASSWORD || '111111', // 비밀번호
+  password: process.env.DB_PASSWORD || '1111', // 비밀번호
   waitForConnections: true,
   // Pool에 획득할 수 있는 connection이 없을 때,
   // true면 요청을 queue에 넣고 connection을 사용할 수 있게 되면 요청을 실행하며, false이면 즉시 오류를 내보내고 다시 요청

--- a/config/jwt.config.js
+++ b/config/jwt.config.js
@@ -2,9 +2,16 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 export const jwtConfig = {
-  secretKey: process.env.TOKKEN_SECRET,
+  secretKey: process.env.TOKEN_SECRET,
   options: {
-    algorithm: process.env.TOKKEN_ALGORITHM,
-    expiresIn: process.env.TOKKEN_EXPIRE,
+    algorithm: process.env.TOKEN_ALGORITHM,
+    expiresIn: process.env.TOKEN_EXPIRE,
+  },
+}
+export const jwtRefreshConfig = {
+  secretKey: process.env.TOKEN_SECRET,
+  options: {
+    algorithm: process.env.TOKEN_ALGORITHM,
+    expiresIn: process.env.TOKEN_REFRESH_EXPIRE,
   },
 }

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -29,6 +29,12 @@ export const status = {
     code: 'AUTH2001',
     message: '구글 로그인 완료!',
   },
+  TOKEN_LOGIN_SUCCESS: {
+    status: 200,
+    isSuccess: true,
+    code: 'AUTH2001',
+    message: '토큰 로그인 완료!',
+  },
   REGISTER_SUCCESS: {
     status: 200,
     isSuccess: true,
@@ -71,7 +77,7 @@ export const status = {
     status: 400,
     isSuccess: false,
     code: 'TOEKN4002',
-    message: '유효하지 않은 토큰',
+    message: '유효하지 않은 토큰. 재로그인 필요',
   },
   TOKEN_SIGNITURE: {
     status: 400,

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -78,6 +78,7 @@ export const status = {
     isSuccess: false,
     code: 'TOEKN4003',
     message: '토큰 서명 오류',
+  },
   //ERR
   CONTROL_ERROR: {
     status: 400,

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,8 +7,10 @@ module.exports = {
       exec_mode: 'fork',
       //merge_logs: true,
       autorestart: true,
+      ignore_watch: ['node_modules'],
       watch: true,
       // max_memory_restart: "512M",
+      time: true,
     },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,12 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@babel/cli": "^7.23.4",
-        "@babel/core": "^7.23.6",
+        "@babel/cli": "^7.23.9",
+        "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.3",
-        "@babel/node": "^7.22.19",
-        "@babel/preset-env": "^7.23.6",
+        "@babel/node": "^7.23.9",
+        "@babel/preset-env": "^7.23.9",
+        "@babel/register": "^7.23.7",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
@@ -2248,7 +2249,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2339,7 +2339,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3626,7 +3625,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -3907,7 +3905,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -4156,7 +4153,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4375,7 +4371,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
       "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.11"
       },
@@ -5694,7 +5689,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5963,7 +5957,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6890,7 +6883,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
       "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.4",

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -8,37 +8,74 @@ import Axios from 'axios'
 
 //임시
 import dotenv from 'dotenv'
+import {
+  newRefreshTokenLogin,
+  newTokenLogin,
+  tokenLogin,
+} from '../providers/auth.provider.js'
 dotenv.config()
 
 export const authLogin = async (req, res) => {
   try {
-    const provider = req.body.provider
-    if (provider == '0') {
-      console.log('카카오 로그인 요청!')
+    //토큰 확인
+    const tokenResult = await tokenCheck(req, res)
+
+    //Access토큰이 유효한 경우
+    if (tokenResult.status == 1) {
+      console.log('Token로그인 요청: ', tokenResult)
+      return res.send(
+        response(status.TOKEN_LOGIN_SUCCESS, await tokenLogin(tokenResult)),
+      )
+    }
+    //Access토큰은 만료, Refresh토큰이 유효한 경우
+    else if (tokenResult.status == 2) {
+      console.log('newToken로그인 요청: ', tokenResult)
+      return res.send(
+        response(status.TOKEN_LOGIN_SUCCESS, await newTokenLogin(tokenResult)),
+      )
+    }
+    //Access토큰은 유효, Refresh토큰이 만료된 경우
+    else if (tokenResult.status == 3) {
+      console.log('newRefreshToken로그인 요청: ', tokenResult)
       return res.send(
         response(
-          status.KAKAO_LOGIN_SUCCESS,
-          await kakaoLogin(req.headers, req.body),
+          status.TOKEN_LOGIN_SUCCESS,
+          await newRefreshTokenLogin(tokenResult),
         ),
       )
-    } else if (provider == '1') {
-      console.log('구글 로그인 요청!')
-      return res.send(
-        response(
-          status.GOOGLE_LOGIN_SUCCESS,
-          await googleLogin(req.headers, req.body),
-        ),
-      )
-    } //else if (provider == 2) {
-    //     console.log('애플 로그인 요청!')
-    //     res.send(
-    //       response(
-    //         status.REGISTER_SUCCESS,
-    //         await appleLogin(req.headers, req.body),
-    //       ),
-    //     )
-    //   }
-    return res.send(response(status.INVAILD_PROVIDER, null))
+    }
+    //Access, Refresh 토큰이 없거나, 만료,이상인 경우
+    else if (tokenResult.status == -1) {
+      //return res.send(response(status.TOKEN_INVAILD, tokenResult.message))
+      const provider = req.body.provider
+      if (provider == '0') {
+        console.log('카카오 로그인 요청!')
+        return res.send(
+          response(
+            status.KAKAO_LOGIN_SUCCESS,
+            await kakaoLogin(req.headers, req.body),
+          ),
+        )
+      } else if (provider == '1') {
+        console.log('구글 로그인 요청!')
+        return res.send(
+          response(
+            status.GOOGLE_LOGIN_SUCCESS,
+            await googleLogin(req.headers, req.body),
+          ),
+        )
+      } //else if (provider == 2) {
+      //     console.log('애플 로그인 요청!')
+      //     res.send(
+      //       response(
+      //         status.REGISTER_SUCCESS,
+      //         await appleLogin(req.headers, req.body),
+      //       ),
+      //     )
+      //   }
+      return res.send(response(status.INVAILD_PROVIDER, null))
+    }
+    return res.send(response(status.TOKEN_ERROR, null))
   } catch (err) {
     console.log('controller Err: ', err)
     return res.send(response(status.CONTROL_ERROR, null))

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,6 +1,6 @@
 import { response } from '../../config/response.js'
 import { status } from '../../config/response.status.js'
-import { tokenVerify } from '../middlewares/jwt.middleware.js'
+import { tokenVerify, tokenCheck } from '../middlewares/jwt.middleware.js'
 
 import { kakaoLogin, googleLogin } from '../services/auth.service.js'
 
@@ -66,9 +66,7 @@ export const authGoogleRedirectTest = async (req, res) => {
 //임시
 export const authJWT = async (req, res) => {
   try {
-    return res.send(
-      response(status.SUCCESS, await tokenVerify(req.headers['token'])),
-    )
+    return res.send(response(status.SUCCESS, await tokenCheck(req, res)))
   } catch (err) {
     return res.send(err.data)
   }

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -66,7 +66,10 @@ export const authGoogleRedirectTest = async (req, res) => {
 //임시
 export const authJWT = async (req, res) => {
   try {
-    return res.send(response(status.SUCCESS, await tokenCheck(req, res)))
+    console.log(req.headers['token'])
+    return res.send(
+      response(status.SUCCESS, await tokenVerify(req.headers['token'])),
+    )
   } catch (err) {
     return res.send(err.data)
   }

--- a/src/dtos/auth.dto.js
+++ b/src/dtos/auth.dto.js
@@ -1,5 +1,5 @@
 // login response DTO
-export const loginResponseDTO = (user, access_token) => {
+export const loginResponseDTO = (user, accessToken, refreshToken) => {
   user = user[0]
   console.log(user)
   return {
@@ -7,6 +7,7 @@ export const loginResponseDTO = (user, access_token) => {
     email: user.email,
     username: user.username,
     profile_img: user.profile_img,
-    access_Token: access_token,
+    accessToken: accessToken,
+    refreshToken: refreshToken,
   }
 }

--- a/src/middlewares/jwt.middleware.js
+++ b/src/middlewares/jwt.middleware.js
@@ -1,5 +1,6 @@
+import pool from '../../config/db.config'
 import jwt from 'jsonwebtoken'
-import { jwtConfig } from '../../config/jwt.config'
+import { jwtConfig, jwtRefreshConfig } from '../../config/jwt.config'
 import { BaseError } from '../../config/error'
 import { status } from '../../config/response.status'
 
@@ -16,6 +17,12 @@ export const tokenSign = async (user) => {
   return result
 }
 
+export const tokenRefreshSign = async () => {
+  //현재는 username와 email을 payload로 넣었지만 필요한 값을 넣으면 됨!
+  const result = jwt.sign({}, jwtConfig.secretKey, jwtRefreshConfig.options)
+  return result
+}
+
 //토큰 인증
 export const tokenVerify = async (token) => {
   let decoded
@@ -25,7 +32,7 @@ export const tokenVerify = async (token) => {
   } catch (err) {
     if (err.message === 'jwt expired') {
       console.log('TOKEN_EXPIRED')
-      throw new BaseError(status.TOKEN_EXPIRED)
+      return decoded
     } else if (err.message === 'invalid token') {
       console.log('TOKEN_INVALID')
       throw new BaseError(status.TOKEN_INVAILD)
@@ -37,5 +44,82 @@ export const tokenVerify = async (token) => {
       throw new BaseError(status.TOKEN_ERROR)
     }
   }
+  console.log(decoded)
   return decoded
+}
+
+//토큰 인증
+export const tokenCheck = async (req, res, next) => {
+  if (req.headers['access'] === undefined) throw BaseError(status.TOKEN_ERROR)
+
+  const accessToken = tokenVerify(req.headers['access'])
+  const refreshToken = tokenVerify(req.headers['refresh']) // *실제로는 DB 조회
+
+  if (accessToken === undefined) {
+    if (refreshToken === undefined) {
+      console.log('CASE 1')
+      // case1: access token과 refresh token 모두가 만료된 경우
+      throw BaseError(status.TOKEN_LOGIN)
+    } else {
+      console.log('CASE 2')
+      // case2: access token은 만료됐지만, refresh token은 유효한 경우
+      /**
+       *  DB를 조회해서 payload에 담을 값들을 가져오는 로직
+       */
+      const conn = await pool.getConnection()
+      const user = await conn.query(
+        'SELECT * FROM USER WHERE id = ?;',
+        req.body.userId,
+      )
+      console.log(user)
+      const newAccessToken = tokenSign(user)
+      res.cookie('access', newAccessToken)
+      req.cookies.access = newAccessToken
+      return newAccessToken
+    }
+  } else {
+    if (refreshToken === undefined) {
+      console.log('CASE 3')
+      // case3: access token은 유효하지만, refresh token은 만료된 경우
+      let conn
+      try {
+        const newRefreshToken = tokenRefreshSign()
+        conn = await pool.getConnection()
+        await conn.beginTransaction()
+
+        const user = await conn.query(
+          'SELECT * FROM USER WHERE id = ?;',
+          req.body.userId,
+        )
+        await conn.query(
+          `UPDATE oauthid 
+          SET access_toekn = ?
+          WHERE user_id = ?;`,
+          [newRefreshToken, user[0].id],
+        )
+        await conn.commit()
+        conn.release()
+        res.cookie('refresh', newRefreshToken)
+        req.cookies.refresh = newRefreshToken
+        return newRefreshToken
+      } catch (err) {
+        console.log('ADDUSER: ', err)
+
+        try {
+          if (conn) {
+            await conn.rollback()
+          }
+        } catch (rollbackError) {
+          console.error('Error in rollback:', rollbackError)
+        }
+
+        throw new BaseError(status.PARAMETER_IS_WRONG)
+      }
+    } else {
+      // case4: accesss token과 refresh token 모두가 유효한 경우
+      const result = tokenVerify(accessToken)
+      console.log(result)
+      return result
+    }
+  }
 }

--- a/src/models/auth.dao.js
+++ b/src/models/auth.dao.js
@@ -49,6 +49,7 @@ export const addUser = async (
   profileImage,
   provider,
   oauthId,
+  refresh,
 ) => {
   let conn
   try {
@@ -60,7 +61,12 @@ export const addUser = async (
       email,
       profileImage,
     ])
-    await conn.query(insertOauthSql, [result[0].insertId, oauthId, provider])
+    await conn.query(insertOauthSql, [
+      result[0].insertId,
+      oauthId,
+      provider,
+      refresh,
+    ])
     await conn.commit()
     conn.release()
     return result[0].insertId

--- a/src/models/auth.sql.js
+++ b/src/models/auth.sql.js
@@ -11,8 +11,10 @@ export const insertUserSql =
 
 //유저 oauth정보 저장
 export const insertOauthSql =
-  'INSERT INTO oauthid(user_id, access_token, provider) VALUES(?,?,? );'
+  'INSERT INTO oauthid(user_id, id, provider,access_token) VALUES(?,?,?,? );'
+
+export const insertOauthRefreshSql =
+  'UPDATE oauthid SET access_token = ? WHERE user_id = ?;'
 
 export const selectUser = `
     SELECT * FROM user WHERE id = ?`
-

--- a/src/models/auth.sql.js
+++ b/src/models/auth.sql.js
@@ -17,4 +17,4 @@ export const insertOauthRefreshSql =
   'UPDATE oauthid SET access_token = ? WHERE user_id = ?;'
 
 export const selectUser = `
-    SELECT * FROM user WHERE id = ?`
+    SELECT * FROM user WHERE id = ?;`

--- a/src/providers/auth.provider.js
+++ b/src/providers/auth.provider.js
@@ -1,0 +1,41 @@
+import { pool } from '../../config/db.config'
+import { BaseError } from '../../config/error'
+import { status } from '../../config/response.status'
+import { loginResponseDTO } from '../dtos/auth.dto'
+import { tokenSign } from '../middlewares/jwt.middleware'
+import { selectUser } from '../models/auth.sql'
+export const tokenLogin = async (token) => {
+  try {
+    const conn = await pool.getConnection()
+    console.log('Login process: ', token)
+    const user = await conn.query(selectUser, token.result.id)
+    console.log('Token Login Done!')
+    return loginResponseDTO(user[0], token.access, token.refresh)
+  } catch (err) {
+    throw new BaseError(status.PARAMETER_IS_WRONG, err)
+  }
+}
+
+export const newTokenLogin = async (token) => {
+  try {
+    const conn = await pool.getConnection()
+    console.log('newTokenLogin process: ', token)
+    const user = await conn.query(selectUser, token.userId)
+    console.log('newTokenLogin 완료')
+    return loginResponseDTO(user[0], await tokenSign(user[0][0]), token.refresh)
+  } catch (err) {
+    throw new BaseError(status.PARAMETER_IS_WRONG, err)
+  }
+}
+
+export const newRefreshTokenLogin = async (token) => {
+  try {
+    const conn = await pool.getConnection()
+    console.log('newTokenLogin process: ', token)
+    const user = await conn.query(selectUser, token.userId)
+    console.log('newTokenLogin 완료')
+    return loginResponseDTO(user[0], await tokenSign(user[0][0]), token.refresh)
+  } catch (err) {
+    throw new BaseError(status.PARAMETER_IS_WRONG, err)
+  }
+}

--- a/src/routes/auth.route.js
+++ b/src/routes/auth.route.js
@@ -8,7 +8,6 @@ import {
 
 export const authRouter = express.Router({ mergeParams: true })
 
-authRouter.get('/', authGoogleRedirectTest)
 authRouter.post('/login', authLogin)
 authRouter.get('/login', authJWT) //임시
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -8,7 +8,7 @@ import {
   addOauth,
 } from '../models/auth.dao'
 import Axios from 'axios'
-import { tokenSign } from '../middlewares/jwt.middleware'
+import { tokenSign, tokenRefreshSign } from '../middlewares/jwt.middleware'
 
 //카카오 소셜로그인
 export const kakaoLogin = async (headers, body) => {
@@ -41,7 +41,8 @@ export const kakaoLogin = async (headers, body) => {
 
   const user = await getUserByEmail(email)
   if (user == -1) {
-    await addUser(username, email, profileImage, provider, kakaoId)
+    const refresh = await tokenRefreshSign()
+    await addUser(username, email, profileImage, provider, kakaoId, refresh)
     const new_user = await getUserByEmail(email)
     return loginResponseDTO(new_user, await tokenSign(new_user[0]))
   } else {
@@ -49,7 +50,11 @@ export const kakaoLogin = async (headers, body) => {
     if (oauth == -1) {
       await addOauth(user[0].id, kakaoId, provider)
     }
-    return loginResponseDTO(user, await tokenSign(user[0]))
+    return loginResponseDTO(
+      user,
+      await tokenSign(user[0]),
+      oauth[0].access_token,
+    )
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,7 +48,6 @@
   version "7.23.9"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
-  
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.23.5"
@@ -2336,7 +2335,6 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-
 ieee754@^1.1.4, ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz"
@@ -2890,7 +2888,6 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
 
 minimist@^1.2.6:
   version "1.2.8"


### PR DESCRIPTION
## JWT RefreshToken 추가 및 코드 정리

### 구현 내용
- 로그인 로직 수정
- jwt refresh토큰 구현
- DB oauthid 테이블에 저장되는 값 변경. 
(기존: access_token에 플랫폼 별 유저 id 저장 -> 변경: id에 플랫폼 별 유저id 저장. access_token에 유저 refresh token 저장

### To Reviewrs
기존에는 로그인시에 이미 존재하는 회원인지만 확인하고 토큰을 발급하는 로직이었습니다. 변경된 로직은 아래와 같습니다!
```
1.토큰 여부 확인(헤더에 access, refresh가 담겨 있다 가정.)
    2-1. 토큰이 없는 경우
        3-1 로그인 진행
    
    2-2.토큰에 위조, 이상 및 access와 refresh가 만료된 경우
        3-1 재로그인이 필요하다는 응답.

    2-3. access 토큰이 정상인 경우
        3-1. refresh 토큰 확인 후 만료된 경우 재발급 후 로그인
        3-2. refresh 토큰 확인 후 만료되지 않은 경우 바로 로그인

    2-4. 토큰이 만료된 경우
        3-1. refresh 토큰으로 재발급 후 로그인
```
관련해서 재로그인 필요, access재발급, refresh재발급 상황에 나뉘어 DTO를 return하는  tokenChecktoken(req, res)함수와 

단순히 토큰만 확인 후 정상이면 data를 리턴 하는 tokenVerify(token) 함수를 만들어 둔 상태입니다. 
*Controller에서 `tokenCheck(req.headers['access'])` 또는 `tokenVerify(req)` 를 사용해서 리턴 값을 가지고 에러 처리와 userId를 이용하여 service로 넘기면 좋을 것 같습니다.

다만 만들면서 생각이 든 게 프론트 분들이랑 토큰을 어떻게 넘겨서 인증할 지 얘기가 충분하지 않았던 것 같아서 당장은 사용하기 어려울 수도 있겠다 싶어서 얘기를 나누면 좋을 것 같습니다!

### Check List
- [ ] 계획한 구현이 빠짐없이 구현됐는가?
- [ ] 오류없이 제대로 동작하는가?
