### PR TITLE
#91 Fix: 회원정보 수정 응답DTO수정

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -1,6 +1,6 @@
 export const status = {
   // success
-  SUCCESS: { status: 200, isSuccess: true, code: 2000, message: '성공!!' },
+  SUCCESS: { status: 200, isSuccess: true, code: '2000', message: '성공!!' },
 
   //공통
   PARAMETER_IS_WRONG: {
@@ -71,19 +71,19 @@ export const status = {
     status: 200,
     isSuccess: true,
     code: 'ARCHIVE2000',
-    message: '폴더가 성공적으로 삭제되었습니다'
+    message: '폴더가 성공적으로 삭제되었습니다',
   },
   ARCHIVE_LIST_DOESNT_EXIST: {
     status: 404,
     isSuccess: false,
     code: 'ARCHIVE4000',
-    message: '아카이브 리스트가 존재하지 않습니다'
+    message: '아카이브 리스트가 존재하지 않습니다',
   },
   USER_DOESNT_OWN_FOLDER: {
     status: 404,
     isSuccess: false,
     code: 'ARCHIVE4001',
-    message: '유저가 접근할 수 없는 폴더입니다'
+    message: '유저가 접근할 수 없는 폴더입니다',
   },
   //user
   USER_NOT_EXISTS: {

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -21,7 +21,12 @@ export const userEditProfileController = async (req, res) => {
     console.log('Edit user Info : ', req.params.userId)
     const result = await userEditProfileService(req)
     if (result == -2) {
-      return res.send(response(status.NAME_ALREADY_EXISTS, req.body.username))
+      return res.send(
+        response(
+          status.NAME_ALREADY_EXISTS,
+          await userGetInfoProvide(req.params.userId),
+        ),
+      )
     }
     return res.send(response(status.SUCCESS, result))
   } catch (err) {


### PR DESCRIPTION
## Fix: 회원정보 수정 응답DTO수정

### 구현 내용
- 회원정보 수정 기능에서 중복된 닉네임이 있을 시 오류 -> 기존 정보 return

### To Reviewrs
![image](https://github.com/MYPLACE-team/MYPLACE-Backend/assets/67246681/1f67a23e-d357-46ff-ae83-54a3020c7db5)
- 기존 오류 메세지와 중복되는 닉네임을 리턴하는 방식에서 사진과 같이 메세지는 오류임을 알려주되 기존 데이터를 보내도록 수정하였습니다.
- response.status에서 SUCCESS부분의 code가 다른 응답이 String인 경우와 달리 2000(number)이라 String으로 바꿔주었습니다!

### Check List
- [x] 계획한 구현이 빠짐없이 구현됐는가?
- [x] 오류없이 제대로 동작하는가?
